### PR TITLE
Assignment 1: Submission for AlexNelms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,52 +17,270 @@ Fork this repository and fill in each of the SQL files corresponding to the ques
 
 1. [How many bike trips in Q2 2019?](query01.sql)
 
-    This file is filled out for you, as an example.
-
     ```SQL
-    SELECT count(*)
-    FROM indego_trips_2019_q2
+    select count(*)
+    from indego_trips_2019_q2;
     ```
-
     **Result:** 206354
 
 2. [What is the percent change in trips in Q2 2020 as compared to Q2 2019?](query02.sql)
     _Bonus: If you want to get fancier here, you can cast the result to a string and concatenate a `'%'` to the end. For example, `(10 + 3.2)::text || '%' AS perc_change`. This uses the type casting (number to string) and string concatenation operator (`||`, double pipes) that's essentially a `+` for strings._
 
+    ```SQL
+    WITH 
+        trips_2020Q2 as (
+            SELECT * FROM indego_trips_2020_q2
+            )
+    SELECT to_char(
+        (count(*) - 206354)/206354::float8 * 100, '99999.00%')
+    AS perc_change
+    FROM trips_2020Q2
+    ```
+    **Result:** Percent change in trips from 2019Q2 to 2020Q2 is -9.58%
+
 3. [What is the average duration of a trip for 2019?](query03.sql)
+
+    ```SQL
+    WITH 
+        full_time as (
+            SELECT 
+            CAST(EXTRACT(EPOCH FROM (end_time - start_time)) AS int) AS time_difference
+            FROM indego_trips_2019_q2
+        )
+    SELECT 
+        AVG(time_difference)/60 as avg_minutes_per_trip
+    FROM full_time
+    WHERE time_difference IS NOT NULL
+    ```
+    **Result:** Average Duration of 24.696 Minutes per trip in 2019 Q2
 
 4. [What is the average duration of a trip for 2020?](query04.sql)
 
+    ```SQL
+    WITH 
+        full_time as (
+            SELECT 
+        CAST(EXTRACT(EPOCH FROM end_time - start_time) AS int) AS seconds_difference
+            FROM public.indego_trips_2020_q2
+        )
+    SELECT 
+        CAST(AVG(seconds_difference)/60 AS decimal) as avg_minutes_per_trip
+    FROM full_time
+    WHERE seconds_difference IS NOT NULL
+    ```
+    **Result:** Average Duration of 49.781 Minutes per trip in 2020 Q2
+
     _What do you notice about the difference in trip lengths? Give a few explanations for why there could be a difference here._
 
-    **Answer:**
+    **Answer:** Bikeshare users have a variety of reasons to use the bike in Philly, resulting in stark differences in trip length and destinations. Commuters might only need to use the bike from Point A to B, resulting in a 30 minute trip for only one day. A tourist may have a variety of destinations and might not be familiar with the Indego stations, resulting in them borrrowing the bike for their entire stay of a few days. 
 
 5. [What is the longest duration trip?](query05.sql)
 
+    ```SQL
+    WITH 
+    full_time as (
+        SELECT 
+        EXTRACT(EPOCH FROM end_time - start_time)::int AS seconds_difference
+        FROM public.indego_trips_2020_q2
+    )
+    SELECT 
+        MAX(seconds_difference)/86400::FLOAT || ' Days' as longest_trip
+    FROM full_time
+    WHERE seconds_difference IS NOT NULL
+    ```
+    **Result:** For Q2 2020, the longest trip was 29.8 Days
+
     _Why are there so many trips of this duration?_
 
-    **Answer:**
+    **Answer:** Since the longest trip length is almost a month, the Indego platform might remotely end the trip of lost/stolen bikes after a month's time. Another possibility is Indego could have users with unlimited monthly passes, causing users to end their extended ride before their next pay period.
 
 6. [How many trips were shorter than 10 minutes?](query06.sql)
 
+    ```SQL
+    WITH 
+    full_time as (
+        SELECT 
+        EXTRACT(EPOCH FROM end_time - start_time)::int AS seconds_difference
+        FROM public.indego_trips_2020_q2
+    )
+    SELECT 
+        COUNT(seconds_difference) as trips_below_10_mins
+    FROM full_time
+    WHERE seconds_difference < 60*10
+    ```
+    **Result:** For Q2 2020, 46,786 trips were below 10 minutes
+
 7. [How many trips started on one day and ended in the next?](query07.sql)
 
-    _Hint 1: date strings can be parsed using the text type to datetime type conversion function [`to_timestamp`](https://www.postgresql.org/docs/12/functions-formatting.html). See the section on [Template Patterns for Date/Time Formatting](https://www.postgresql.org/docs/12/functions-formatting.html#FUNCTIONS-FORMATTING-DATETIME-TABLE) for options on choosing the right string format. The 2020 dataset has the timestamp in a slightly unusual format so you need to tell PostgreSQL how to parse it. The 2019 data should already be in a good format._
-
-    _Hint 2: Days of the month can be retrieved from a timestamp using the [EXTRACT](https://www.postgresql.org/docs/12/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT) function. See also some of the follow alongs from the Lecture in week 2._
+    ```SQL
+    SELECT 
+    COUNT(*) as trips_ending_the_next_day
+    FROM public.indego_trips_2020_q2
+    WHERE EXTRACT(DOY FROM (start_time)) + 1 = EXTRACT(DOY FROM (end_time))
+    ```
+    **Result:** For Q2 2020, 2,648 trips started and ended on the next day
 
 8. [Give the five most popular stations between 7am and 10am in 2019.](query08.sql)
 
-    _Hint: Use the `EXTRACT` function to get the hour of the day from the timestamp._
+    ```SQL
+    WITH 
+        commute_start_stations AS (
+            SELECT
+                start_station AS station,
+                COUNT(*) AS station_uses
+            FROM public.indego_trips_2020_q2
+            WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6
+            GROUP BY start_station
+        ), commute_end_stations AS (
+            SELECT
+                end_station AS station,
+                COUNT(*) AS station_uses
+            FROM public.indego_trips_2020_q2
+            WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6
+            GROUP BY end_station
+        ), commute_stations AS (
+            SELECT 
+            starts.station_uses + ends.station_uses as station_uses,
+            ends.station as station
+            FROM commute_start_stations AS starts
+            JOIN commute_end_stations AS ends
+            ON starts.station = ends.station   
+        )
+    SELECT 
+        *
+    FROM commute_stations
+    ORDER BY station_uses DESC
+    LIMIT 5
+    ```
+    **Result:** See table below for 2019 top stations used (includes both end & start but not double-counted)
+    | station | station_uses |
+    |:-------:|:------------:|
+    | 3021    |        1,696 |
+    | 3102    |        1,369 |
+    | 3195    |        1,366 |
+    | 3010    |        1,365 |
+    | 3020    |        1,300 |
 
 9. [List all the passholder types and number of trips for each.](query09.sql)
 
+    ```SQL
+    SELECT
+    passholder_type,
+    COUNT(*) as trips
+    FROM public.indego_trips_2020_q2
+    GROUP BY passholder_type
+    ```
+    **Result:** For 2020: Day Pass (38,165 trips), Indego30 (12,9905 trips), Indego365 (18,515 trip), IndegoFlex (1 trip)
+
 10. [Using the station status dataset, find the distance in meters of all stations from Meyerson Hall.](query10.sql)
+
+    ```SQL
+    WITH station_statuses AS (
+        SELECT
+        *,
+        ST_Distance(
+            ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+            ST_MakePoint(latitude, longitude),
+            FALSE
+            ) AS meyerson_distance
+        FROM public.lr_rt1mwwjuex9ienf202w AS station_status_file
+    )
+    SELECT 
+        meyerson_distance
+    FROM station_statuses
+    ```
+    **Result:** It's a column
 
 11. [What is the average distance (in meters) of all stations from Meyerson Hall?](query11.sql)
 
+    ```SQL
+    WITH station_statuses AS (
+        SELECT
+        *,
+        ST_Distance(
+            ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+            ST_MakePoint(latitude, longitude),
+            FALSE
+            ) AS meyerson_distance
+        FROM public.lr_rt1mwwjuex9ienf202w
+    )
+    SELECT 
+        AVG(meyerson_distance) AS avg_dist_to_meyerson
+    FROM station_statuses
+    ```
+    **Result:** Average of 2902.012 meters from all stations to meyerson
+
 12. [How many stations are within 1km of Meyerson Hall?](query12.sql)
+
+    ```SQL
+    WITH station_statuses AS (
+        SELECT
+        *,
+        ST_Distance(
+            ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+            ST_MakePoint(latitude, longitude),
+            FALSE
+            ) AS meyerson_distance
+        FROM public.lr_rt1mwwjuex9ienf202w
+    )
+    SELECT 
+        COUNT(meyerson_distance) AS stations_within_1km
+    FROM station_statuses
+    WHERE meyerson_distance <= 1000
+    ```
+    **Result:** 21 stations within 1km of Meyerson
 
 13. [Which station is furthest from Meyerson Hall?](query13.sql)
 
+    ```SQL
+    WITH station_statuses AS (
+        SELECT
+        *,
+        ST_Distance(
+            ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+            ST_MakePoint(latitude, longitude),
+            FALSE
+            ) AS meyerson_distance
+        FROM public.lr_rt1mwwjuex9ienf202w
+    ), 
+    max_dist AS (
+        SELECT 
+            MAX(meyerson_distance) as max_distance
+        FROM station_statuses
+    )
+    SELECT
+        id as station_id,
+        name as station_name,
+        meyerson_distance
+    FROM station_statuses
+    WHERE meyerson_distance = (SELECT max_distance FROM max_dist)
+    ```
+    **Result:** Furthest station from Meyerson: Station ID 3153, Station Name Thompson & Palmer, Adaire School, & a Meyerson Distance of 7000.08638912 meters
+
 14. [Which station is closest to Meyerson Hall?](query14.sql)
+
+    ```SQL
+    WITH station_statuses AS (
+        SELECT
+        *,
+        ST_Distance(
+            ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+            ST_MakePoint(latitude, longitude),
+            FALSE
+            ) AS meyerson_distance
+        FROM public.lr_rt1mwwjuex9ienf202w
+    ), 
+    min_dist AS (
+        SELECT 
+            MIN(meyerson_distance) as min_distance
+        FROM station_statuses
+    )
+    SELECT
+        cartodb_id as cartodb_id,
+        id as station_id,
+        name as station_name,
+        meyerson_distance
+    FROM station_statuses
+    WHERE meyerson_distance = (SELECT min_distance FROM min_dist)
+    ```
+    **Result:** Closest station to Meyerson: Station ID 3208, Station Name 34th & Spruce, & a Meyerson Distance of 80.26416575 meters

--- a/query01.sql
+++ b/query01.sql
@@ -4,4 +4,6 @@
 
 -- Enter your SQL query here
 select count(*)
-from indego_trips_2019_q2
+from indego_trips_2019_q2;
+
+-- Answer: 206354 trips

--- a/query02.sql
+++ b/query02.sql
@@ -9,8 +9,8 @@
 -- Enter your SQL query here
 
 WITH 
-	trips_2020Q2 as (
-    	 SELECT * FROM public.indego_trips_2021_q2
+    trips_2020Q2 as (
+        SELECT * FROM public.indego_trips_2021_q2
     ),
     trips_2019Q2 as (
     	 SELECT * FROM public.indego_trips_2019_q2

--- a/query02.sql
+++ b/query02.sql
@@ -1,34 +1,16 @@
 /*
   What is the percent change in trips in Q2 2020 as compared to Q2 2019?
-
-  Using only the table from Q2 2020 and the number calculated in the previous
-  question, find the percent change of number of trips in Q2 2020 as compared
-  to 2019. Remember you can do calculations in the select clause.
 */
 
 -- Enter your SQL query here
 
 WITH 
     trips_2020Q2 as (
-        SELECT * FROM public.indego_trips_2021_q2
-    ),
-    trips_2019Q2 as (
-    	 SELECT * FROM public.indego_trips_2019_q2
-    ),
-    count_2020Q2 AS (SELECT COUNT(*) FROM trips_2020Q2),
-    count_2019Q2 AS (SELECT COUNT(*) FROM trips_2019Q2)
+        SELECT * FROM indego_trips_2020_q2
+    )
 SELECT to_char(
-    (count_2020Q2.count - count_2019Q2.count)/count_2020Q2.count::float8, '99999.00%'
-  )
+    (count(*) - 206354)/206354::float8 * 100, '99999.00%')
   AS perc_change
-FROM count_2020Q2, count_2019Q2
+FROM trips_2020Q2
 
-/*
-  Bonus: If you want to get fancier here, you can cast the result to a string
-  and concatenate a '%' to the end. For example:
-
-      (10 + 3.2)::text || '%' AS perc_change
-
-  This uses the type casting (number to string) and string concatenation
-  operator (`||`, double pipes) that's essentially a `+` for strings.
-*/
+--Percent change in trips from 2019Q2 to 2020Q2 = -9.58%

--- a/query02.sql
+++ b/query02.sql
@@ -7,9 +7,21 @@
 */
 
 -- Enter your SQL query here
-select ...
 
-
+WITH 
+	trips_2020Q2 as (
+    	 SELECT * FROM public.indego_trips_2021_q2
+    ),
+    trips_2019Q2 as (
+    	 SELECT * FROM public.indego_trips_2019_q2
+    ),
+    count_2020Q2 AS (SELECT COUNT(*) FROM trips_2020Q2),
+    count_2019Q2 AS (SELECT COUNT(*) FROM trips_2019Q2)
+SELECT to_char(
+    (count_2020Q2.count - count_2019Q2.count)/count_2020Q2.count::float8, '99999.00%'
+  )
+  AS perc_change
+FROM count_2020Q2, count_2019Q2
 
 /*
   Bonus: If you want to get fancier here, you can cast the result to a string

--- a/query03.sql
+++ b/query03.sql
@@ -7,8 +7,8 @@
 WITH 
     full_time as (
         SELECT 
-      CAST(EXTRACT(EPOCH FROM (end_time - start_time)) AS int) AS time_difference
-      	FROM public.indego_trips_2019_q2
+        CAST(EXTRACT(EPOCH FROM (end_time - start_time)) AS int) AS time_difference
+      	FROM indego_trips_2019_q2
     )
 SELECT 
 	AVG(time_difference)/60 as avg_minutes_per_trip

--- a/query03.sql
+++ b/query03.sql
@@ -3,4 +3,11 @@
 */
 
 -- Enter your SQL query here
-select ...
+
+WITH 
+    full_time as (
+        SELECT EXTRACT(EPOCH FROM (TO_TIMESTAMP(end_time, 'MM/DD/YYYY HH24:MI') - TO_TIMESTAMP(start_time, 'MM/DD/YYYY HH24:MI'))) AS time_difference
+      	FROM public.indego_trips_2020_q2
+    )
+SELECT *
+FROM full_time

--- a/query03.sql
+++ b/query03.sql
@@ -6,8 +6,13 @@
 
 WITH 
     full_time as (
-        SELECT EXTRACT(EPOCH FROM (TO_TIMESTAMP(end_time, 'MM/DD/YYYY HH24:MI') - TO_TIMESTAMP(start_time, 'MM/DD/YYYY HH24:MI'))) AS time_difference
-      	FROM public.indego_trips_2020_q2
+        SELECT 
+      CAST(EXTRACT(EPOCH FROM (end_time - start_time)) AS int) AS time_difference
+      	FROM public.indego_trips_2019_q2
     )
-SELECT *
+SELECT 
+	AVG(time_difference)/60 as avg_minutes_per_trip
 FROM full_time
+WHERE time_difference IS NOT NULL
+
+-- Average Duration of 24.696 Minutes per trip in 2019 Q2

--- a/query04.sql
+++ b/query04.sql
@@ -3,4 +3,16 @@
 */
 
 -- Enter your SQL query here
-select ...
+
+WITH 
+    full_time as (
+        SELECT 
+      CAST(EXTRACT(EPOCH FROM (TO_TIMESTAMP(end_time, 'MM/DD/YYYY HH24:MI') - TO_TIMESTAMP(start_time, 'MM/DD/YYYY HH24:MI'))) AS int) AS time_difference
+      	FROM public.indego_trips_2020_q2
+    )
+SELECT 
+	AVG(time_difference)/60 as avg_minutes_per_trip
+FROM full_time
+WHERE time_difference IS NOT NULL
+
+-- Average Duration of 49.781 Minutes per trip in 2020 Q2

--- a/query04.sql
+++ b/query04.sql
@@ -7,12 +7,12 @@
 WITH 
     full_time as (
         SELECT 
-      CAST(EXTRACT(EPOCH FROM (TO_TIMESTAMP(end_time, 'MM/DD/YYYY HH24:MI') - TO_TIMESTAMP(start_time, 'MM/DD/YYYY HH24:MI'))) AS int) AS time_difference
+      CAST(EXTRACT(EPOCH FROM end_time - start_time) AS int) AS seconds_difference
       	FROM public.indego_trips_2020_q2
     )
 SELECT 
-	AVG(time_difference)/60 as avg_minutes_per_trip
+	CAST(AVG(seconds_difference)/60 AS decimal) as avg_minutes_per_trip
 FROM full_time
-WHERE time_difference IS NOT NULL
+WHERE seconds_difference IS NOT NULL
 
 -- Average Duration of 49.781 Minutes per trip in 2020 Q2

--- a/query05.sql
+++ b/query05.sql
@@ -13,4 +13,4 @@ SELECT
 FROM full_time
 WHERE seconds_difference IS NOT NULL
 
--- longest trip was 29.8 Days
+-- For Q2 2020, the longest trip was 29.8 Days

--- a/query05.sql
+++ b/query05.sql
@@ -2,5 +2,15 @@
   What is the longest duration trip?
 */
 
--- Enter your SQL query here
-select ...
+WITH 
+  full_time as (
+    SELECT 
+    EXTRACT(EPOCH FROM end_time - start_time)::int AS seconds_difference
+    FROM public.indego_trips_2020_q2
+  )
+SELECT 
+    MAX(seconds_difference)/86400::FLOAT || ' Days' as longest_trip
+FROM full_time
+WHERE seconds_difference IS NOT NULL
+
+-- longest trip was 29.8 Days

--- a/query06.sql
+++ b/query06.sql
@@ -13,4 +13,4 @@ SELECT
 FROM full_time
 WHERE seconds_difference < 60*10
 
--- Answer: 46,786 trips below 10 minutes
+-- Answer: For Q2 2020, 46,786 trips below 10 minutes

--- a/query06.sql
+++ b/query06.sql
@@ -2,5 +2,15 @@
   How many trips were shorter than 10 minutes?
 */
 
--- Enter your SQL query here
-select ...
+WITH 
+  full_time as (
+    SELECT 
+    EXTRACT(EPOCH FROM end_time - start_time)::int AS seconds_difference
+    FROM public.indego_trips_2020_q2
+  )
+SELECT 
+    COUNT(seconds_difference) as trips_below_10_mins
+FROM full_time
+WHERE seconds_difference < 60*10
+
+-- Answer: 46,786 trips below 10 minutes

--- a/query07.sql
+++ b/query07.sql
@@ -2,5 +2,9 @@
   How many trips started on one day and ended in the next?
 */
 
--- Enter your SQL query here
-select ...
+SELECT 
+    COUNT(*)
+FROM public.indego_trips_2020_q2
+WHERE EXTRACT(DAY FROM (end_time)) <> EXTRACT(DAY FROM (start_time))
+
+-- Answer: 3,000 trips started and ended in different days

--- a/query07.sql
+++ b/query07.sql
@@ -3,8 +3,8 @@
 */
 
 SELECT 
-    COUNT(*)
+  COUNT(*) as trips_ending_the_next_day
 FROM public.indego_trips_2020_q2
-WHERE EXTRACT(DAY FROM (end_time)) <> EXTRACT(DAY FROM (start_time))
+WHERE EXTRACT(DOY FROM (start_time)) + 1 = EXTRACT(DOY FROM (end_time))
 
--- Answer: 3,000 trips started and ended in different days
+-- Answer: For Q2 2020, 2,648 trips started and ended on the next day

--- a/query08.sql
+++ b/query08.sql
@@ -7,15 +7,15 @@ WITH
     SELECT
         start_station AS station,
         COUNT(*) AS station_uses
-    FROM public.indego_trips_2020_q2
+    FROM public.indego_trips_2019_q2
     WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6
     GROUP BY start_station
   ), commute_end_stations AS (
     SELECT
         end_station AS station,
         COUNT(*) AS station_uses
-    FROM public.indego_trips_2020_q2
-    WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6
+    FROM public.indego_trips_2019_q2
+    WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6 AND end_station <> start_station
     GROUP BY end_station
   ), commute_stations AS (
     SELECT 
@@ -31,4 +31,15 @@ FROM commute_stations
 ORDER BY station_uses DESC
 LIMIT 5
 
--- Answer: Top 5 Stations (Start & End Stations combined) between 7am & 10am: 3057 (1532 uses), 3052 (690 uses), 3102 (614 uses), 3010 (515 uses), 3208 (513 uses)
+Answer: Top 5 Stations (Start & End Stations combined) between 7am & 10am in the table below
+/*
+Answer: Top 5 Stations (Start & End Stations combined) between 7am & 10am in the table below
+(includes both end & start but not double-counted)
+    | station | station_uses |
+    |:-------:|:------------:|
+    | 3021    |        1,696 |
+    | 3102    |        1,369 |
+    | 3195    |        1,366 |
+    | 3010    |        1,365 |
+    | 3020    |        1,300 |
+*/

--- a/query08.sql
+++ b/query08.sql
@@ -2,5 +2,33 @@
   Give the five most popular stations between 7am and 10am in 2019.
 */
 
--- Enter your SQL query here
-select ...
+WITH 
+  commute_start_stations AS (
+    SELECT
+        start_station AS station,
+        COUNT(*) AS station_uses
+    FROM public.indego_trips_2020_q2
+    WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6
+    GROUP BY start_station
+  ), commute_end_stations AS (
+    SELECT
+        end_station AS station,
+        COUNT(*) AS station_uses
+    FROM public.indego_trips_2020_q2
+    WHERE EXTRACT(HOUR FROM (end_time)) < 10 AND EXTRACT(HOUR FROM (start_time)) > 6
+    GROUP BY end_station
+  ), commute_stations AS (
+    SELECT 
+      starts.station_uses + ends.station_uses as station_uses,
+      ends.station as station
+    FROM commute_start_stations AS starts
+    JOIN commute_end_stations AS ends
+    ON starts.station = ends.station   
+  )
+SELECT 
+    *
+FROM commute_stations
+ORDER BY station_uses DESC
+LIMIT 5
+
+-- Answer: Top 5 Stations (Start & End Stations combined) between 7am & 10am: 3057 (1532 uses), 3052 (690 uses), 3102 (614 uses), 3010 (515 uses), 3208 (513 uses)

--- a/query09.sql
+++ b/query09.sql
@@ -5,5 +5,10 @@
   and the number of trips taken by `passholder_type`.
 */
 
--- Enter your SQL query here
-select ...
+SELECT
+  passholder_type,
+  COUNT(*) as trips
+FROM public.indego_trips_2020_q2
+GROUP BY passholder_type
+
+-- Answer: Day Pass (38,165 trips), Indego30 (12,9905 trips), Indego365 (18,515 trip), IndegoFlex (1 trip)

--- a/query10.sql
+++ b/query10.sql
@@ -3,5 +3,18 @@
   from Meyerson Hall.
 */
 
--- Enter your SQL query here
-select ...
+WITH station_statuses AS (
+  SELECT
+  *,
+  ST_Distance(
+    ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+    ST_MakePoint(latitude, longitude),
+    FALSE
+    ) AS meyerson_distance
+  FROM public.lr_rt1mwwjuex9ienf202w
+)
+SELECT 
+  meyerson_distance
+FROM station_statuses
+
+-- Answer:

--- a/query11.sql
+++ b/query11.sql
@@ -2,5 +2,18 @@
   What is the average distance (in meters) of all stations from Meyerson Hall?
 */
 
--- Enter your SQL query here
-select ...
+WITH station_statuses AS (
+  SELECT
+  *,
+  ST_Distance(
+    ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+    ST_MakePoint(latitude, longitude),
+    FALSE
+    ) AS meyerson_distance
+  FROM public.lr_rt1mwwjuex9ienf202w
+)
+SELECT 
+  AVG(meyerson_distance) AS avg_dist_to_meyerson
+FROM station_statuses
+
+-- Answer: Average of 2902.012 meters from all stations to meyerson

--- a/query12.sql
+++ b/query12.sql
@@ -2,5 +2,19 @@
   How many stations are within 1km of Meyerson Hall?
 */
 
--- Enter your SQL query here
-select ...
+WITH station_statuses AS (
+  SELECT
+  *,
+  ST_Distance(
+    ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+    ST_MakePoint(latitude, longitude),
+    FALSE
+    ) AS meyerson_distance
+  FROM public.lr_rt1mwwjuex9ienf202w
+)
+SELECT 
+  COUNT(meyerson_distance) AS stations_within_1km
+FROM station_statuses
+WHERE meyerson_distance <= 1000
+
+-- Answer: 21 stations within 1km of Meyerson

--- a/query13.sql
+++ b/query13.sql
@@ -5,5 +5,27 @@
   name, and distance from Meyerson Hall.
 */
 
--- Enter your SQL query here
-select ...
+WITH station_statuses AS (
+  SELECT
+  *,
+  ST_Distance(
+    ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+    ST_MakePoint(latitude, longitude),
+    FALSE
+    ) AS meyerson_distance
+  FROM public.lr_rt1mwwjuex9ienf202w
+  ), 
+  max_dist AS (
+  SELECT 
+    MAX(meyerson_distance) as max_distance
+  FROM station_statuses
+  )
+SELECT
+ cartodb_id as cartodb_id,
+ id as station_id,
+ name as station_name,
+  meyerson_distance
+FROM station_statuses
+WHERE meyerson_distance = (SELECT max_distance FROM max_dist)
+
+-- Answer: Station ID 3153, Station Name Thompson & Palmer, Adaire School, & a Meyerson Distance of 7000.08638912 meters

--- a/query14.sql
+++ b/query14.sql
@@ -5,5 +5,27 @@
   name, and distance from Meyerson Hall.
 */
 
--- Enter your SQL query here
-select ...
+WITH station_statuses AS (
+  SELECT
+  *,
+  ST_Distance(
+    ST_setsrid(ST_MakePoint(39.952296926596986, -75.19268734458572),4326),
+    ST_MakePoint(latitude, longitude),
+    FALSE
+    ) AS meyerson_distance
+  FROM public.lr_rt1mwwjuex9ienf202w
+  ), 
+  min_dist AS (
+  SELECT 
+    MIN(meyerson_distance) as min_distance
+  FROM station_statuses
+  )
+SELECT
+ cartodb_id as cartodb_id,
+ id as station_id,
+ name as station_name,
+  meyerson_distance
+FROM station_statuses
+WHERE meyerson_distance = (SELECT min_distance FROM min_dist)
+
+-- Answer: Station ID 3208, Station Name 34th & Spruce, & a Meyerson Distance of 80.26416575 meters


### PR DESCRIPTION
# Assignment 1 – Alex Nelms

**Due: Sept 20, 2021 by 3:30pm ET**

Here are my answers to each query:

1. How many bike trips in Q2 2019?
   **Result:** 206354

2. What is the percent change in trips in Q2 2020 as compared to Q2 2019?
    **Result:** Percent change in trips from 2019Q2 to 2020Q2 is -9.58%

3. What is the average duration of a trip for 2019?
   **Result:** Average Duration of 24.696 Minutes per trip in 2019 Q2

4. What is the average duration of a trip for 2020?
    **Result:** Average Duration of 49.781 Minutes per trip in 2020 Q2

    _What do you notice about the difference in trip lengths? Give a few explanations for why there could be a difference here._
    **Answer:** Bikeshare users have a variety of reasons to use the bike in Philly, resulting in stark differences in trip length and destinations. Commuters might only need to use the bike from Point A to B, resulting in a 30 minute trip for only one day. A tourist may have a variety of destinations and might not be familiar with the Indego stations, resulting in them borrrowing the bike for their entire stay of a few days. 

5. What is the longest duration trip?
    **Result:** For Q2 2020, 46,786 trips were below 10 minutes

    _Why are there so many trips of this duration?_
    **Answer:** Since the longest trip length is almost a month, the Indego platform might remotely end the trip of lost/stolen bikes after a month's time. Another possibility is Indego could have users with unlimited monthly passes, causing users to end their extended ride before their next pay period.

6. How many trips were shorter than 10 minutes?
    **Result:** For Q2 2020, 46,786 trips were below 10 minutes

7. How many trips started on one day and ended in the next?
    **Result:** For Q2 2020, 2,648 trips started and ended on the next day

8. Give the five most popular stations between 7am and 10am in 2019
    **Result:** See table below for 2019 top stations used (includes both end & start but not double-counted)
    | station | station_uses |
    |:-------:|:------------:|
    | 3021    |        1,696 |
    | 3102    |        1,369 |
    | 3195    |        1,366 |
    | 3010    |        1,365 |
    | 3020    |        1,300 |

9. List all the passholder types and number of trips for each.
    **Result:** For 2020: Day Pass (38,165 trips), Indego30 (12,9905 trips), Indego365 (18,515 trip), IndegoFlex (1 trip)

10. Using the station status dataset, find the distance in meters of all stations from Meyerson Hall.
    **Result:** It's a column

11. What is the average distance (in meters) of all stations from Meyerson Hall?
    **Result:** Average of 2902.012 meters from all stations to meyerson

12. How many stations are within 1km of Meyerson Hall?
    **Result:** 21 stations within 1km of Meyerson

13. Which station is furthest from Meyerson Hall?
    **Result:** Furthest station from Meyerson: Station ID 3153, Station Name Thompson & Palmer, Adaire School, & a Meyerson Distance of 7000.08638912 meters

14. Which station is closest to Meyerson Hall?
    **Result:** Closest station to Meyerson: Station ID 3208, Station Name 34th & Spruce, & a Meyerson Distance of 80.26416575 meters
